### PR TITLE
Fixed invalid ref to $address when checking for V6

### DIFF
--- a/src/Internet/Ip.php
+++ b/src/Internet/Ip.php
@@ -43,7 +43,7 @@ class Ip
         }
 
         $version = self::IPV6;
-        if (false === filter_var($this->address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
+        if (false === filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
             $version = self::IPV4;
         }
 


### PR DESCRIPTION
The check for ipv4/6 was always defaulting back to ipv4 as the check was comparing to an empty tring
